### PR TITLE
Remove bottle :unneeded

### DIFF
--- a/zoom.rb
+++ b/zoom.rb
@@ -4,9 +4,7 @@ class Zoom < Formula
     url "https://thomasmonfre.com/zoom.tar.gz"
     sha256 "05ec04099fae91efb80208ba08dbd2a911ca0b1f82ad6b95772d1bb371ca22ce"
     version "1.1.0"
-    
-    bottle :unneeded
-  
+      
     def install
       bin.install "zoom"
     end


### PR DESCRIPTION
Removed `bottle :unneeded` from `zoom.rb` since it was removed in `homebrew-core` in [June, 2021](https://github.com/Homebrew/brew/pull/11239).

closes #1 